### PR TITLE
added support for service keys

### DIFF
--- a/lib/vcap.js
+++ b/lib/vcap.js
@@ -88,6 +88,11 @@ var VcapClient = module.exports = function (info) {
         service_plan_guid: { type: 'string' },
     });
 
+    this.serviceKeys = collections.create('service_keys', {
+	service_instance_guid: { type: 'string' },
+	name: { type: 'string' },
+    });
+
     this.orgs = this.organizations = collections.create('organizations', {
         name: { type: 'string' }
     });


### PR DESCRIPTION
Added the following to vcap.js to support obtaining service_keys:

this.serviceKeys = collections.create('service_keys', {
        service_instance_guid: { type: 'string' },
        name: { type: 'string' },
    });

Please pull and release on npm...
